### PR TITLE
Allow empty href

### DIFF
--- a/reMarked.js
+++ b/reMarked.js
@@ -468,7 +468,7 @@ reMarked = function(opts) {
 					href = this.e.getAttribute("href"),
 					title = this.e.title ? ' "' + this.e.title + '"' : "";
 
-				if (!href || href == kids || href[0] == "#" && !cfg.hash_lnks)
+				if (!this.e.hasAttribute("href") || href == kids || href[0] == "#" && !cfg.hash_lnks)
 					return kids;
 
 				if (cfg.link_list)

--- a/tests/md_htm/marked/Empty Href.htm
+++ b/tests/md_htm/marked/Empty Href.htm
@@ -1,0 +1,9 @@
+<p>
+  This is an <a href="">empty Link</a>.
+</p>
+<p>
+  This is a <a href="#hash">hashtag Link</a>.
+</p>
+<p>
+  This is a <a href="https://google.com">real Link</a>.
+</p>

--- a/tests/md_htm/marked/Empty Href.htm
+++ b/tests/md_htm/marked/Empty Href.htm
@@ -2,8 +2,5 @@
   This is an <a href="">empty Link</a>.
 </p>
 <p>
-  This is a <a href="#hash">hashtag Link</a>.
-</p>
-<p>
   This is a <a href="https://google.com">real Link</a>.
 </p>

--- a/tests/md_src/Empty Href.md
+++ b/tests/md_src/Empty Href.md
@@ -1,5 +1,3 @@
 This is an [empty Link]().
 
-This is a [hashtag Link](#).
-
 This is a [real Link](https://google.com).

--- a/tests/md_src/Empty Href.md
+++ b/tests/md_src/Empty Href.md
@@ -1,0 +1,5 @@
+This is an [empty Link]().
+
+This is a [hashtag Link](#).
+
+This is a [real Link](https://google.com).


### PR DESCRIPTION
I think that empty href should be supported in your project.  A lot of markdown parsers support it (including the one Github uses).  Let me know if you agree.

If you do agree, let me know what you think about this PR.  Thanks :)

P.S. great project.  Ran it against original markdown specs and it performed way better than to-markdown.
